### PR TITLE
Change the shell interpreter

### DIFF
--- a/spark
+++ b/spark
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # spark
 # https://github.com/holman/spark


### PR DESCRIPTION
POSIX compliant bourne shell implementations do not support array variables.  In
particular Debian/Ubuntu's /bin/dash (which is linked from /bin/sh) fails to
parse the script.

It should also fail in other platforms such as Solaris or BSD.
