### PR TITLE
Fix usage text formatting

### DIFF
--- a/spark
+++ b/spark
@@ -30,14 +30,16 @@ set -e
 # Returns nothing.
 help()
 {
-  echo "spark\n"
-  echo "USAGE:"
-  echo "  spark [comma,separated,value,list]\n"
-  echo "EXAMPLES:"
-  echo "  spark 1,5,22,13,53"
-  echo "  ▁▁▃▂▇"
-  echo "  spark 0,30,55,80,33,150"
-  echo "  ▁▂▃▅▂▇"
+  cat <<-EOF
+  spark
+  USAGE:
+    spark [comma,separated,value,list]
+  EXAMPLES:
+    spark 1,5,22,13,53
+    ▁▁▃▂▇
+    spark 0,30,55,80,33,150
+    ▁▂▃▅▂▇
+EOF
 }
 
 # The actual fun characters we are generating in the sparkline.


### PR DESCRIPTION
This uses a heredoc to make the help function clearer and not require escape sequences which may or may not require the -e switch to echo depending on the shell.
