### PR TITLE
Suppress newline without escape

### DIFF
--- a/spark
+++ b/spark
@@ -117,7 +117,7 @@ print_ticks()
 {
   for number in ${numbers[@]}
   do
-    echo $"$(print_tick $number)\c"
+    echo -n $"$(print_tick $number)"
   done
   echo ""
 }


### PR DESCRIPTION
This uses echo -n to suppress newlines rather than the continuation character escape sequence, which requires echo -e in some shell environments.
