### PR TITLE
rm 'set -e' & quote per Riviera's advice; 'set -e' breaks on no trailing...

### DIFF
--- a/spark
+++ b/spark
@@ -23,7 +23,6 @@
 #
 #   spark -h
 #   # => Prints the spark help text.
-set -e
 
 # Prints the help text for spark.
 #


### PR DESCRIPTION
... newline (see issue #37 for detailed discussion)
