### PR TITLE
Python rewrite

### DIFF
--- a/spark
+++ b/spark
@@ -65,14 +65,20 @@ class Data(object):
         self.arg = arg.strip()
         self.split = re.split("[,\s]+", self.arg)
         self.numbers = [float((x.strip())) for x in self.split]
+        self.number_of_ticks = len(ticks)
+        self.setup()
 
+    def setup(self):
         self.sorted = sorted(self.numbers)
         self.max = self.sorted[-1]
         self.min = self.sorted[0]
-        self.number_of_ticks = len(ticks)
-        self.distance = self.max / self.number_of_ticks
-        if self.distance == 0:
-            self.distance = 1
+        if self.min < 0:
+            self.numbers = [(x - self.min) for x in self.numbers]
+            self.setup()
+        else:
+            self.distance = self.max / self.number_of_ticks
+            if self.distance == 0:
+                self.distance = 1
 
     def print_tick(self, number):
         """

--- a/spark-test.sh
+++ b/spark-test.sh
@@ -65,3 +65,10 @@ it_charts_no_tier_0() {
 
   test $graph = '▂▄▅▇█'
 }
+
+it_charts_negatives() {
+  data="-10,0,10"
+  graph="$($spark -- $data)"
+
+  test $graph = '▁▄█'
+}


### PR DESCRIPTION
Sorry, I couldn't resist. Don't worry about saying "thanks, but no thanks"; I won't mind. If you're interested, here's what I did:
- Modified the syntax to python (i.e. minimze git diff --word-diff) with all tests passing
- Change to a full pythonized version with all tests passing
- Added full float support (gh-28); this changed the sparkles slightly
- Added support for negatives

This all is about an order of magnitude faster:

```
/tmp/spark $ time ./spark -- '0,10,100,1,10,1,10,20,10,40,50,30,10,30,50,60,40,20,304,50,40,50,50'
▁▁▃▁▁▁▁▁▁▂▂▁▁▁▂▂▂▁█▂▂▂▂

real    0m0.023s
user    0m0.013s
sys 0m0.010s
/tmp/spark $ time ./spark.sh -- '0,10,100,1,10,1,10,20,10,40,50,30,10,30,50,60,40,20,304,50,40,50,50'
▁▁▁▃▁▁▁▁▁▁▂▂▁▁▁▂▂▂▁█▂▂▂▂

real    0m0.290s
user    0m0.092s
sys 0m0.229s
```

If this is something that anyone wants to consider, my next step would be to remove print_tick loop, since with float support we can compute the tick directly.

But now I should get back to real work. :)
