### PR TITLE
Show help for no arguments if stdin is a terminal

### DIFF
--- a/spark
+++ b/spark
@@ -75,9 +75,11 @@ spark()
   echo
 }
 
-[ "$1" == '-h' ] && {
-  help
-  exit
-}
+# show help for no arguments if stdin is a terminal
+if ([ -z $1 ] && [ -t 0 ]) || [ "$1" == '-h' ]
+then
+	help
+	exit
+fi
 
 spark ${@:-`cat`}


### PR DESCRIPTION
As announced, here's a solution to not hang on user input when called from the terminal without arguments.
