### PR TITLE
Tiny fix: getting rid of ( subshell ) and adding "" to preserve the space.

### DIFF
--- a/spark
+++ b/spark
@@ -65,6 +65,7 @@ spark()
 
   # print ticks
   local ticks=(▁ ▂ ▃ ▄ ▅ ▆ ▇ █)
+  # this is fine, but normal people don't understand it -_-
   local f=$(( (($max-$min)<<8)/(${#ticks[@]}-1) ))
   (( f < 1 )) && f=1
 
@@ -79,7 +80,7 @@ spark()
 [[ ${#BASH_SOURCE[@]} -eq 1 ]] || return
 
 # show help for no arguments if stdin is a terminal
-if ([ -z $1 ] && [ -t 0 ]) || [ "$1" == '-h' ]
+if { [ -z "$1" ] && [ -t 0 ] ; } || [ "$1" == '-h' ]
 then
 	help
 	exit


### PR DESCRIPTION
Characters ( and ) creates subshell and then executes the list of commands, { is smarter and faster.

When using -z you need "" or you will be evaluating the ']' character if $1 is unset.
