### PR TITLE
Support SPARK_MIN/SPARK_MAX env variables.

### DIFF
--- a/spark
+++ b/spark
@@ -63,6 +63,9 @@ spark()
     numbers=$numbers${numbers:+ }$n
   done
 
+  [ -n "$SPARK_MIN" ] && min=$SPARK_MIN
+  [ -n "$SPARK_MAX" ] && max=$SPARK_MAX
+
   # print ticks
   local ticks=(▁ ▂ ▃ ▄ ▅ ▆ ▇ █)
 


### PR DESCRIPTION
Hi,

This tiny patch adds support for forcing min/max values based on environment variables.

without min/max (the drawing might look bad in the git markdown, but on the console it's better).

``` sh
$ seq 10 20 | spark 
▁▂▂▃▃▅▅▇▇
```

with min/max:

``` sh
$ seq 10 20 | SPARK_MIN=0 spark 
▃▃▅▅▇▇██

$ seq 10 20 | SPARK_MAX=30 spark 
▁▁▂▂▂▃▃▃

$ seq 10 20 | SPARK_MIN=0 SPARK_MAX=30 spark 
▅▅▅▅▇▇▇▇
```

The goal is to be able to plot average load over the last hour (or any other period).
and without setting the min/max, it will produce the same chart if it was all 1 or all 0.

``` sh
 sar -q |
   awk '$4 ~ /^[0-9]+/ {print $4*100}' |
   tail -n 24 |
   SPARK_MIN=0 SPARK_MAX=$((100*$(nproc))) ./spark
```

thanks for this nice script,
- gordon
