### PR TITLE
Use an exit status of 0

### DIFF
--- a/spark
+++ b/spark
@@ -82,7 +82,7 @@ EOF
   if { [ -z "$1" ] && [ -t 0 ] ; } || [ "$1" == '-h' ]
   then
     help
-    exit
+    exit 0
   fi
 
   spark ${@:-`cat`}


### PR DESCRIPTION
Use an exit status `0` showing that the script quit successfully.
