### PR TITLE
Remove echo, Create _echo Function, Use printf

### DIFF
--- a/spark
+++ b/spark
@@ -27,6 +27,16 @@
 # Generates sparklines.
 #
 # $1 - The data we'd like to graph.
+_echo()
+{
+  if [ "X$1" = "X-n" ]; then
+    shift
+    printf "%s" "$*"
+  else
+    printf "%s\n" "$*"
+  fi
+}
+
 spark()
 {
   local n numbers=
@@ -53,9 +63,9 @@ spark()
 
   for n in $numbers
   do
-    echo -n ${ticks[$(( ((($n-$min)<<8)/$f) ))]}
+    _echo -n ${ticks[$(( ((($n-$min)<<8)/$f) ))]}
   done
-  echo
+  _echo
 }
 
 # If we're being sourced, don't worry about such things


### PR DESCRIPTION
According to the POSIX standard `echo` has an unspecified behavior if using `-n`

Create private function `_echo` to use printf

References:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#tag_20_37_16
http://wiki.bash-hackers.org/scripting/nonportable#echo_command

Fixes #64
