### PR TITLE
Use $0 in the usage, instead of hardcoding the name "spark"

### DIFF
--- a/spark
+++ b/spark
@@ -73,17 +73,18 @@ if [ "$BASH_SOURCE" == "$0" ]; then
   # Prints the help text for spark.
   help()
   {
+    local spark=$(basename $0)
     cat <<EOF
 
     USAGE:
-      spark [-h|--help] VALUE,...
+      $spark [-h|--help] VALUE,...
 
     EXAMPLES:
-      spark 1 5 22 13 53
+      $spark 1 5 22 13 53
       ▁▁▃▂█
-      spark 0,30,55,80,33,150
+      $spark 0,30,55,80,33,150
       ▁▂▃▄▂█
-      echo 9 13 5 17 1 | spark
+      echo 9 13 5 17 1 | $spark
       ▄▆▂█▁
 EOF
   }


### PR DESCRIPTION
This is required in case spark is renamed to something else due to packaging issues.
