### PR TITLE
Add multiline option

### DIFF
--- a/spark
+++ b/spark
@@ -69,7 +69,7 @@ spark()
       local thre=$(( ($max-$min)*($height-$i)/$height+$min-1 ))
       if [ "$n" -gt "$thre" ]
       then
-        local lvl=$(( ((($n-$thre+1)<<8)/$f) ))
+        local lvl=$(( ((($n-$thre-1)<<8)/$f) ))
         (( lvl >= ${#ticks[@]} )) && lvl=$(( ${#ticks[@]}-1 ))
         _echo -n ${ticks[$lvl]}
       else


### PR DESCRIPTION
**SAFE TO MERGE** [Open for suggestions]

This new feature allows to display the graph on several lines, as requested in #55. The default is 1 line to preserve compatibility, and the height can be set using the `SPARK_HEIGHT` variable as follows.

``` sh
SPARK_HEIGHT=3 ./spark 16 10 7 4 6 7 10
█      
██    █
███▄███
```

**Caveats:**
- It only works with a proper fixed-size font
- There is always a small line skip

Feel free to improve, I am not an expert.
