### PR TITLE
[Improvement] Use a larger tick if data is constant

### DIFF
--- a/spark
+++ b/spark
@@ -58,6 +58,9 @@ spark()
   # print ticks
   local ticks=(▁ ▂ ▃ ▄ ▅ ▆ ▇ █)
 
+  # use a high tick if data is constant
+  (( min == max )) && ticks=(▅ ▆)
+
   local f=$(( (($max-$min)<<8)/(${#ticks[@]}-1) ))
   (( f < 1 )) && f=1
 


### PR DESCRIPTION
This patch simply tests if `min` and `max` are the same. In that case, the tick printed will no longer be the smaller one, as requested in #72.

What do you think? Maybe an option to switch back to the original behavior?
