### PR TITLE
Replaced _echo function with printf

### DIFF
--- a/spark
+++ b/spark
@@ -64,7 +64,8 @@ then
   # Prints the help text for spark.
   help()
   {
-    local spark=$(basename $0)
+    local spark=${0##*/}
+
     cat <<EOF
 
     USAGE:


### PR DESCRIPTION
There's no need for a bash function. If we want to use printf, we just do.
