### PR TITLE
Add colored ticks version

### DIFF
--- a/spark
+++ b/spark
@@ -37,6 +37,17 @@ _echo()
   fi
 }
 
+REGULAR_TICKS="▁:▂:▃:▄:▅:▆:▇:█"
+FIRE_TICKS="$(echo "$(tput setaf 228)▁"):$(echo "$(tput setaf 227)▂"):$(echo "$(tput setaf 226)▃"):$(echo "$(tput setaf 220)▄"):$(echo "$(tput setaf 214)▅"):$(echo "$(tput setaf 208)▆"):$(echo "$(tput setaf 202)▇"):$(echo "$(tput setaf 196)█")"
+
+
+ticks_styles=(
+  $REGULAR_TICKS
+  $FIRE_TICKS
+)
+
+tick_style=0
+
 spark()
 {
   local n numbers=
@@ -56,7 +67,7 @@ spark()
   done
 
   # print ticks
-  local ticks=(▁ ▂ ▃ ▄ ▅ ▆ ▇ █)
+  local ticks=($(echo ${ticks_styles[$tick_style]} | tr : " "))
 
   # use a high tick if data is constant
   (( min == max )) && ticks=(▅ ▆)
@@ -69,6 +80,33 @@ spark()
     _echo -n ${ticks[$(( ((($n-$min)<<8)/$f) ))]}
   done
   _echo
+}
+
+parse_args()
+{
+  OPTIND=1
+
+  while getopts "h?c:" opt; do
+    case "$opt" in
+      c)
+        case "$OPTARG" in
+          fire)
+            tick_style=1
+            ;;
+        esac
+        ;;
+    esac
+  done
+
+  shift $((OPTIND-1))
+
+  [ "$1" = "--" ] && shift
+
+  if [ $# -eq 0 ]; then
+    data=$(cat)
+  else
+    data=$@
+  fi
 }
 
 # If we're being sourced, don't worry about such things
@@ -99,5 +137,7 @@ EOF
     exit 0
   fi
 
-  spark ${@:-`cat`}
+  parse_args ${@:-`cat`}
+
+  spark $data
 fi

--- a/spark
+++ b/spark
@@ -118,7 +118,10 @@ if [ "$BASH_SOURCE" == "$0" ]; then
     cat <<EOF
 
     USAGE:
-      $spark [-h|--help] VALUE,...
+      $spark [-h|--help|-c fire] VALUE,...
+
+    OPTIONS:
+      -c fire  Output fire colored ticks (smallest = yellow, largest = red)
 
     EXAMPLES:
       $spark 1 5 22 13 53

--- a/spark-test.sh
+++ b/spark-test.sh
@@ -76,3 +76,11 @@ it_equalizes_at_midtier_on_same_data() {
 
   test $graph = '▅▅▅▅'
 }
+
+it_charts_in_fire_colored_ticks() {
+  data="1,2,3,4,5,6,7,8"
+  graph="$($spark -c fire $data)"
+
+  expected_graph="$(echo "$(tput setaf 228)▁")$(echo "$(tput setaf 227)▂")$(echo "$(tput setaf 226)▃")$(echo "$(tput setaf 220)▄")$(echo "$(tput setaf 214)▅")$(echo "$(tput setaf 208)▆")$(echo "$(tput setaf 202)▇")$(echo "$(tput setaf 196)█")"
+  test $graph = $expected_graph
+}


### PR DESCRIPTION
This PR adds a command line option "-c fire" to output the graph colored in fire (smallest tick is yellow, largest is red).

Adding additional palettes should be easy: just add a colon-separated string to the `ticks_style` array and a option statement for the `case` of the `c` parameter setting the correct index in the variable `tick_style`
