### PR TITLE
Use new USGS API for earthquake list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Number of commits to the github/github Git repository, by author:
   ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▂▁▁▅▁▂▁▁▁▂▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 ```
 
-Magnitude of earthquakes over 1.0 in the last 24 hours:
+Magnitude of earthquakes worldwide 2.5 and above in the last 24 hours:
 
 ```sh
-› curl http://earthquake.usgs.gov/earthquakes/catalogs/eqs1day-M1.txt --silent |
+› curl earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.csv --silent |
   sed '1d' |
-  cut -d, -f9 |
+  cut -d, -f5 |
   spark
-  ▅▆▂▃▂▂▂▅▂▂▅▇▂▂▂▃▆▆▆▅▃▂▂▂▁▂▂▆▁▃▂▂▂▂▃▂▆▂▂▂▁▂▂▃▂▂▃▂▂▃▂▂▁▂▂▅▂▂▆▆▅▃▆
+▃█▅▅█▅▃▃▅█▃▃▁▅▅▃▃▅▁▁▃▃▃▃▃▅▃█▅▁▃▅▃█▃▁
 ```
 
 Code visualization. The number of characters of `spark` itself, by line, ignoring empty lines:


### PR DESCRIPTION
The USGS apparently has updated their earthquake list so http://earthquake.usgs.gov/earthquakes/catalogs/eqs1day-M1.txt no longer provides a list of earthquakes. I've updated it to the new API, changing to be 2.5+ mag since that was a more reasonable length spark chart today.