### PR TITLE
Note about fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ If you're on OS X, spark is also on [Homebrew][brew]:
 
     brew install spark
 
+Depending on the fonts you have in your system and you use in the
+terminal, you might end up with irregular blocks. This is due to some
+fonts providing only part of the blocks, while the others are taken from
+a different, fallback font.
+
 ## usage
 
 Just run `spark` and pass it a list of numbers (comma-delimited, spaces,


### PR DESCRIPTION
I initially had issues with the highest block, that was not showing fine. It turned out that the font I had in the terminal - "Monaco" - was providing its own rendition of that block, without providing the intermediate ones. Switching to Menlo fixed it. I don't know if you want to "make names" in the README.md though, so I kept the message generic.