### PR TITLE
Allow 'x' for unknown data, show as '×'

### DIFF
--- a/spark
+++ b/spark
@@ -49,9 +49,11 @@ spark()
     # on Linux (or with bash4) we could use `printf %.0f $n` here to
     # round the number but that doesn't work on OS X (bash3) nor does
     # `awk '{printf "%.0f",$1}' <<< $n` work, so just cut it off
-    n=${n%.*}
-    (( n < min )) && min=$n
-    (( n > max )) && max=$n
+    if [ $n != x ]; then
+      n=${n%.*}
+      (( n < min )) && min=$n
+      (( n > max )) && max=$n
+    fi
     numbers=$numbers${numbers:+ }$n
   done
 
@@ -66,7 +68,11 @@ spark()
 
   for n in $numbers
   do
-    _echo -n ${ticks[$(( ((($n-$min)<<8)/$f) ))]}
+    if [ $n = x ]; then
+      _echo -n ×
+    else
+      _echo -n ${ticks[$(( ((($n-$min)<<8)/$f) ))]}
+    fi
   done
   _echo
 }


### PR DESCRIPTION
This small patch interprets 'x' in the input as an unknown value, showing '×' in the output:

```
$ echo 1 4 2 x 6 10 | ./spark 
▁▃▁×▄█
$
```