### PR TITLE
feat: Nix flakes support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Nix
+result/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Nix
-result/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1651114127,
+        "narHash": "sha256-/lLC0wkMZkAdA5e1W76SnJzbhfOGDvync3VRHJMtAKk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6766fb6503ae1ebebc2a9704c162b2aef351f921",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "A very basic flake";
+
+  outputs = { self, nixpkgs }: {
+
+    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
+
+    defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
+
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "▁▂▃▅▂▇ in your shell.";
 
   outputs = { self, nixpkgs }: {
+    defaultPackage.x86_64-linux = self.packages.x86_64-linux.spark;
 
-    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
-
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
-
+    packages.x86_64-linux.spark =
+      let pkgs = import nixpkgs { system = "x86_64-linux"; };
+      in pkgs.writeShellScriptBin "spark" (builtins.readFile ./spark);
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A very basic flake";
+  description = "▁▂▃▅▂▇ in your shell.";
 
   outputs = { self, nixpkgs }: {
 


### PR DESCRIPTION
This PR implements a Nix [flake](https://nixos.wiki/wiki/Flakes) to easily run and use `spark` on Nix enabled systems.